### PR TITLE
Updating of existing pyenv installs should default to no

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here is the list of all variables and their default values:
 * ``pyenv_owner: "{{ ansible_env.USER }}"``
 * ``pyenv_python_versions: ["3.4.1"]``
 * ``pyenv_virtualenvs: [{ venv_name: "latest", py_version: "3.4.1" }]``
-* ``should_update_existing_pyenv_install: no``
+* ``pyenv_should_update_existing_pyenv_install: no``
 
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Here is the list of all variables and their default values:
 * ``pyenv_owner: "{{ ansible_env.USER }}"``
 * ``pyenv_python_versions: ["3.4.1"]``
 * ``pyenv_virtualenvs: [{ venv_name: "latest", py_version: "3.4.1" }]``
+* ``should_update_existing_pyenv_install: no``
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for pyenv
 pyenv_path: "{{ ansible_env.HOME }}/pyenv"
 pyenv_owner: "{{ ansible_env.USER }}"
+should_update_existing_pyenv_install: no
 pyenv_python_versions:
   - 3.4.1
 pyenv_virtualenvs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for pyenv
 pyenv_path: "{{ ansible_env.HOME }}/pyenv"
 pyenv_owner: "{{ ansible_env.USER }}"
-pyenv_should_update_existing_pyenv_install: no
+pyenv_update_git_install: no
 pyenv_python_versions:
   - 3.4.1
 pyenv_virtualenvs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for pyenv
 pyenv_path: "{{ ansible_env.HOME }}/pyenv"
 pyenv_owner: "{{ ansible_env.USER }}"
-should_update_existing_pyenv_install: no
+pyenv_should_update_existing_pyenv_install: no
 pyenv_python_versions:
   - 3.4.1
 pyenv_virtualenvs:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -29,12 +29,14 @@
   git:
     repo: https://github.com/yyuu/pyenv.git
     dest: "{{ pyenv_path }}"
+    update: {{should_update_existing_pyenv_install}}
 
 - name: Install PyEnv-virtualenv plugin
   sudo: no
   git:
     repo: https://github.com/yyuu/pyenv-virtualenv.git
     dest: "{{ pyenv_path }}/plugins/pyenv-virtualenv"
+    update: {{should_update_existing_pyenv_install}}
 
 - name: Install .pyenvrc
   sudo: no

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -29,14 +29,14 @@
   git:
     repo: https://github.com/yyuu/pyenv.git
     dest: "{{ pyenv_path }}"
-    update: {{should_update_existing_pyenv_install}}
+    update: "{{pyenv_should_update_existing_pyenv_install}}"
 
 - name: Install PyEnv-virtualenv plugin
   sudo: no
   git:
     repo: https://github.com/yyuu/pyenv-virtualenv.git
     dest: "{{ pyenv_path }}/plugins/pyenv-virtualenv"
-    update: {{should_update_existing_pyenv_install}}
+    update: "{{pyenv_should_update_existing_pyenv_install}}"
 
 - name: Install .pyenvrc
   sudo: no

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -29,14 +29,14 @@
   git:
     repo: https://github.com/yyuu/pyenv.git
     dest: "{{ pyenv_path }}"
-    update: "{{pyenv_should_update_existing_pyenv_install}}"
+    update: "{{pyenv_update_git_install}}"
 
 - name: Install PyEnv-virtualenv plugin
   sudo: no
   git:
     repo: https://github.com/yyuu/pyenv-virtualenv.git
     dest: "{{ pyenv_path }}/plugins/pyenv-virtualenv"
-    update: "{{pyenv_should_update_existing_pyenv_install}}"
+    update: "{{pyenv_update_git_install}}"
 
 - name: Install .pyenvrc
   sudo: no


### PR DESCRIPTION
Bumped into this now, running the role (just to install a new virtualenv) ended up in updating pyenv from master and introducing a bug..  Most of the times I don't need this, 