### PR TITLE
add build tools installation

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -8,6 +8,7 @@
     pkg: "{{ item }}"
     state: present
   with_items:
+    - build-essential
     - git
     # On Ubuntu 12.04 build may fail with the following error:
     #   python-build: wget (< 1.14) doesn't support Server Name Indication.


### PR DESCRIPTION
In the official ubuntu 16.10 vagrant box, I had to install the build-essential package because build tools like gcc where not available.

I think you should had it as a mandatory dependencies for the python compilation part