### PR TITLE
create bashrc file if not present

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -52,6 +52,7 @@
               regexp="\.pyenvrc$"
               line="source {{ pyenv_path }}/.pyenvrc"
               state=present
+              create=yes
   become_user: "{{pyenv_owner}}"
 
 - name: Add pyenv autocomplete in .bashrc


### PR DESCRIPTION
I have just run this role on one of my coworker computer and I don't why but his user did not have a bashrc file in his home folder. So I added the settings to create it automatically.