### PR TITLE
user, system install and support RedHat

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ Role Variables
 
 Here is the list of all variables and their default values:
 
-* ``pyenv_path: "{{ ansible_env.HOME }}/pyenv"``
+* ``pyenv_env: "user"``
+* ``pyenv_path: "{% if pyenv_env == 'user' %}{{ ansible_env.HOME }}/pyenv{% else %}/usr/local/pyenv{% endif %}"``
 * ``pyenv_owner: "{{ ansible_env.USER }}"``
 * ``pyenv_python_versions: ["3.4.1"]``
 * ``pyenv_virtualenvs: [{ venv_name: "latest", py_version: "3.4.1" }]``
 * ``pyenv_update_git_install: no``
 * ``pyenv_enable_autocompletion: no``
-
+* ``pyenv_setting_path: "{% if pyenv_env == 'user' %}~/.bashrc{% else %}/etc/profile.d/pyenv.sh{% endif %}"``
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 # defaults file for pyenv
-pyenv_path: "{{ ansible_env.HOME }}/pyenv"
+pyenv_env: "user"
+pyenv_path: "{% if pyenv_env == 'user' %}{{ ansible_env.HOME }}/pyenv{% else %}/usr/local/pyenv{% endif %}"
 pyenv_owner: "{{ ansible_env.USER }}"
+pyenv_setting_path: "{% if pyenv_env == 'user' %}~/.bashrc{% else %}/etc/profile.d/pyenv.sh{% endif %}"
 pyenv_update_git_install: no
 pyenv_enable_autocompletion: no
 pyenv_python_versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,12 +18,12 @@ galaxy_info:
   # platform on this list, let us know and we'll get it added!
   #
   platforms:
-  #- name: EL
-  #  versions:
+    - name: EL
+      versions:
   #  - all
   #  - 5
-  #  - 6
-  #  - 7
+       - 6
+       - 7
   #- name: GenericUNIX
   #  versions:
   #  - all
@@ -77,6 +77,7 @@ galaxy_info:
   #  - raring
   #  - saucy
        - trusty
+       - xenial
        - yakkety
   #- name: SLES
   #  versions:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,6 +2,7 @@
 - name: Ensure apt cache is up to date
   apt:
     update_cache: yes
+  become: true
 
 - name: Install prerequisite packages
   apt:
@@ -14,6 +15,7 @@
     #   python-build: wget (< 1.14) doesn't support Server Name Indication.
     #   Please install curl (>= 7.18.1) and try again
     - curl
+  become: true
 
 - name: Install development packages necessary for building Python
   apt:
@@ -24,53 +26,5 @@
     - libbz2-dev
     - libsqlite3-dev
     - libreadline-dev
+  become: true
 
-- name: Install PyEnv
-  git:
-    repo: https://github.com/yyuu/pyenv.git
-    dest: "{{ pyenv_path }}"
-    update: "{{pyenv_update_git_install}}"
-  become_user: "{{pyenv_owner}}"
-
-- name: Install PyEnv-virtualenv plugin
-  git:
-    repo: https://github.com/yyuu/pyenv-virtualenv.git
-    dest: "{{ pyenv_path }}/plugins/pyenv-virtualenv"
-    update: "{{pyenv_update_git_install}}"
-  become_user: "{{pyenv_owner}}"
-
-- name: Install .pyenvrc
-  template:
-    src: ".pyenvrc.j2"
-    dest: "{{ pyenv_path }}/.pyenvrc"
-    owner: "{{ pyenv_owner }}"
-    group: "{{ pyenv_owner }}"
-    mode: "0644"
-
-- name: Load pyenv env variables in .bashrc
-  lineinfile: dest="~/.bashrc"
-              regexp="\.pyenvrc$"
-              line="source {{ pyenv_path }}/.pyenvrc"
-              state=present
-              create=yes
-  become_user: "{{pyenv_owner}}"
-
-- name: Add pyenv autocomplete in .bashrc
-  lineinfile: dest="~/.bashrc"
-              regexp="pyenv\.bash$"
-              line="source {{ pyenv_path }}/completions/pyenv.bash"
-              state=present
-  when: pyenv_enable_autocompletion
-  become_user: "{{pyenv_owner}}"
-
-- name: Install Python interpreters "{{ pyenv_python_versions }}"
-  shell: . {{ pyenv_path }}/.pyenvrc && pyenv install {{ item }}
-         creates="{{ pyenv_path }}/versions/{{ item }}/bin/python"
-  with_items: "{{pyenv_python_versions}}"
-  become_user: "{{pyenv_owner}}"
-
-- name: Create virtual environments
-  shell: . {{ pyenv_path }}/.pyenvrc && pyenv virtualenv {{ item.py_version }} {{ item.venv_name }}
-         creates="{{ pyenv_path }}/versions/{{ item.venv_name }}/bin/python"
-  with_items: "{{pyenv_virtualenvs}}"
-  become_user: "{{pyenv_owner}}"

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,20 @@
+---
+- name: Install prerequisite packages
+  yum:
+    pkg: "{{ item }}"
+    state: present
+  with_items:
+    - git
+  become: true
+
+- name: Install development packages necessary for building Python
+  yum:
+    pkg: "{{ item }}"
+    state: present
+  with_items:
+    - gcc
+    - libselinux-python
+    - zlib-devel
+    - openssl-devel
+  become: true
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,49 @@
+---
+- name: Install PyEnv
+  git:
+    repo: https://github.com/pyenv/pyenv.git
+    dest: "{{ pyenv_path }}"
+    update: "{{ pyenv_update_git_install }}"
+
+- name: Install PyEnv-virtualenv plugin
+  git:
+    repo: https://github.com/yyuu/pyenv-virtualenv.git
+    dest: "{{ pyenv_path }}/plugins/pyenv-virtualenv"
+    update: "{{ pyenv_update_git_install }}"
+
+- name: Install .pyenvrc
+  template:
+    src: ".pyenvrc.j2"
+    dest: "{{ pyenv_path }}/.pyenvrc"
+    owner: "{{ pyenv_owner }}"
+    group: "{{ pyenv_owner }}"
+    mode: "0644"
+
+- name: "Load pyenv env variables in {{ pyenv_setting_path }}"
+  lineinfile: dest="{{ pyenv_setting_path }}"
+              regexp="\.pyenvrc$"
+              line="source {{ pyenv_path }}/.pyenvrc"
+              state=present
+              create=yes
+
+- name: "Add pyenv autocomplete in {{ pyenv_setting_path }}"
+  lineinfile: dest="{{ pyenv_setting_path }}"
+              regexp="pyenv\.bash$"
+              line="source {{ pyenv_path }}/completions/pyenv.bash"
+              state=present
+  when: pyenv_enable_autocompletion
+
+- name: Install Python interpreters "{{ pyenv_python_versions }}"
+  shell: . {{ pyenv_path }}/.pyenvrc && pyenv install {{ item }}
+         creates="{{ pyenv_path }}/versions/{{ item }}/bin/python"
+  with_items: "{{ pyenv_python_versions }}"
+
+- name: Create virtual environments
+  shell: . {{ pyenv_path }}/.pyenvrc && pyenv virtualenv {{ item.py_version }} {{ item.venv_name }}
+         creates="{{ pyenv_path }}/versions/{{ item.venv_name }}/bin/python"
+  with_items: "{{ pyenv_virtualenvs }}"
+
+- name: Set pyenv global
+  shell: . {{ pyenv_path }}/.pyenvrc && pyenv global {{ pyenv_global }} && pyenv rehash
+  when: pyenv_global is defined
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,13 @@
 ---
 - include: Debian.yml
   when: ansible_os_family == "Debian"
+- include: RedHat.yml
+  when: ansible_os_family == "RedHat"
+
+- include: install.yml
+  become_user: "{{ pyenv_owner }}"
+  when: pyenv_env == "user"
+- include: install.yml
+  become: true
+  when: pyenv_env == "system"
+


### PR DESCRIPTION
Hello.
I'm using CentOS.
But this role doesn't support RedHat. So I implemented it.
And I also implemented `system` install.

## TODO
- add options
    - `pyenv_env`: user or system. **default** is user
    - `pyenv_setting_path `: pyenv env variables settting path. **default** if pyenv_env is user, this option is `~/.bashrc`
    - `pyenv_global`: If this option is defined, call `pyenv global xxxx`.
- add RedHat.yml

## Verification
### Environment
- centos 6
- centos 7
- ubuntu trusty64
- ubuntu xenial64

### playbook

**system install**

```
- hosts: all 
  vars:
    pyenv_env: "system"
  roles:
    - ansible-galaxy-pyenv
```

**user install**

```
- hosts: all 
  roles:
    - ansible-galaxy-pyenv
```