### PR TITLE
pyenv should update its python list before trying to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ script:
   - echo localhost > inventory
   - ansible-playbook -i inventory test.yml --syntax-check
   - ansible-playbook -i inventory test.yml --connection=local --sudo -vvv --diff
+  - ansible-playbook -i inventory test_update.yml --syntax-check
+  - ansible-playbook -i inventory test_update.yml --connection=local --sudo -vvv --diff
 #after_failure:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ pyenv_python_versions:
   - 3.5.0
 pyenv_virtualenvs:
   - { venv_name: "latest", py_version: "3.5.0" }
+
+pyenv_update: no

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,7 @@
     repo: https://github.com/pyenv/pyenv-update.git
     dest: "{{ pyenv_path }}/plugins/pyenv-update"
     update: "{{ pyenv_update_git_install }}"
+  when: pyenv_update
 
 - name: Install .pyenvrc
   template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,6 +11,12 @@
     dest: "{{ pyenv_path }}/plugins/pyenv-virtualenv"
     update: "{{ pyenv_update_git_install }}"
 
+- name: Install PyEnv-update plugin
+  git:
+    repo: https://github.com/pyenv/pyenv-update.git
+    dest: "{{ pyenv_path }}/plugins/pyenv-update"
+    update: "{{ pyenv_update_git_install }}"
+
 - name: Install .pyenvrc
   template:
     src: ".pyenvrc.j2"
@@ -33,6 +39,10 @@
               state=present
   when: pyenv_enable_autocompletion
 
+- name: Update Pyenv interpreter list
+  shell: . {{ pyenv_path }}/.pyenvrc && pyenv update
+  when: pyenv_update
+  
 - name: Install Python interpreters "{{ pyenv_python_versions }}"
   shell: . {{ pyenv_path }}/.pyenvrc && pyenv install {{ item }}
          creates="{{ pyenv_path }}/versions/{{ item }}/bin/python"

--- a/test_update.yml
+++ b/test_update.yml
@@ -1,6 +1,7 @@
 - hosts: all
   vars_files:
     - 'defaults/main.yml'
+    - 'tests/test_update_vars.yml'
   tasks:
     - debug:
         msg: "Owner: {{ pyenv_owner }}"

--- a/tests/test_update_vars.yml
+++ b/tests/test_update_vars.yml
@@ -1,0 +1,2 @@
+---
+pyenv_update: yes


### PR DESCRIPTION
Hi, 
When you have an old pyenv install, the python versions liste is not up to date.
So if you try to install another version of python, it might not be in the pyenv list.

To solve this issue we can update pyenv every time we try we try to install a version of python.

This is a small change that implement this.
Thanks 