### PR TITLE
Address #15 by relying on a default group for files

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,7 +23,6 @@
     src: ".pyenvrc.j2"
     dest: "{{ pyenv_path }}/.pyenvrc"
     owner: "{{ pyenv_owner }}"
-    group: "{{ pyenv_owner }}"
     mode: "0644"
 
 - name: "Load pyenv env variables in {{ pyenv_setting_path }}"


### PR DESCRIPTION
This change relies on the idea that default group settings for newly created files is enough for `<pyenv_path>/.pyenvrc` from a security viewpoint, and that they could be overridden by http://docs.ansible.com/ansible/latest/modules/acl_module.html from outside this role, if necessary.