### PR TITLE
Use include_tasks since include is deprecated.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
-- include: Debian.yml
+- include_tasks: Debian.yml
   when: ansible_os_family == "Debian"
-  
-- include: RedHat.yml
+
+- include_tasks: RedHat.yml
   when: ansible_os_family == "RedHat"
 
 
-- include: install.yml
+- include_tasks: install.yml
   become: true
   become_user: "{{ pyenv_owner }}"
   when: pyenv_env == "user"
-  
-- include: install.yml
+
+- include_tasks: install.yml
   become: true
   when: pyenv_env == "system"
 


### PR DESCRIPTION
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale.. This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.