### PR TITLE
Update debian packages with pyenv recommended packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,15 @@ pyenv_debian_packages:
   - libbz2-dev
   - libsqlite3-dev
   - libreadline-dev
+  - zlib1g-dev
+  - wget 
+  - llvm 
+  - libncurses5-dev 
+  - xz-utils
+  - tk-dev
+  - libxml2-dev
+  - libxmlsec1-dev
+  - libffi-dev
 pyenv_redhat_packages:
   - git
   - gcc


### PR DESCRIPTION
Pyenv has a page that lists the recommended packages for a build environment:
https://github.com/pyenv/pyenv/wiki#suggested-build-environment

This PR fixes the debian defaults

Related issues: #23 #25 #28 