### PR TITLE
Disable rehashing for system installs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ pyenv_python_versions:
   - 3.5.0
 pyenv_virtualenvs:
   - { venv_name: "latest", py_version: "3.5.0" }
+# For a system install, the shims dir will not be writable by users, disable rehashing
+pyenv_init_options: "{% if pyenv_env != 'user' %}--no-rehash{% endif %}"
 
 pyenv_update: no
 

--- a/templates/.pyenvrc.j2
+++ b/templates/.pyenvrc.j2
@@ -2,4 +2,4 @@
 # -------------------------------------
 export PYENV_ROOT="{{ pyenv_path }}"
 export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
+eval "$(pyenv init - {{ pyenv_init_options}})"


### PR DESCRIPTION
When a system install is created, the init will give the following error:

`pyenv: cannot rehash: /opt/pyenv/shims isn't writable`

This patch adds options to the pyenv init