### PR TITLE
Only update apt cache when it is stale

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,6 +2,7 @@
 - name: Ensure apt cache is up to date
   apt:
     update_cache: yes
+    cache_valid_time: "{{ 48 * 60 * 60 }}"  # consider the cache to be valid within 48 hours
   become: true
 
 - name: Install development packages necessary for building Python


### PR DESCRIPTION
Avoids an unnecessary `apt update` if the cache is recent enough. This also helps to make the role idempotent.