### PR TITLE
Install make on RedHat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ pyenv_debian_packages:
   - libxmlsec1-dev
   - libffi-dev
 pyenv_redhat_packages:
+  - make
   - git
   - gcc
   - libselinux-python


### PR DESCRIPTION
I noticed installing any Python would fail on a clean CentOS system because of missing `make`. 