### PR TITLE
Improve idempotency by allowing the user to uninstall existing Python interpreters that lack desired Python configure options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq python-apt python-pycurl
 install:
-  - pip install ansible==1.9.4
+  - pip install ansible==2.5.0
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory test.yml --syntax-check

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ pyenv_update: no
 
 # additional options for the build process, e.g "--enable-shared"
 pyenv_python_configure_opts: ""
+pyenv_uninstall_python_w_wrong_configure_opts: no
 
 pyenv_debian_packages:
   - build-essential
@@ -30,9 +31,9 @@ pyenv_debian_packages:
   - libsqlite3-dev
   - libreadline-dev
   - zlib1g-dev
-  - wget 
-  - llvm 
-  - libncurses5-dev 
+  - wget
+  - llvm
+  - libncurses5-dev
   - xz-utils
   - tk-dev
   - libxml2-dev

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.5
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -1,0 +1,25 @@
+---
+- name: Create folder for custom facts
+  file:
+    path: /etc/ansible/facts.d
+    state: directory
+
+- name: Copy over check-configure-options.py
+  template:
+    src: templates/check-configure-options.py.j2
+    dest: /etc/ansible/facts.d/check-configure-options.py
+    owner: "{{ pyenv_owner }}"
+    group: "{{ pyenv_owner }}"
+    mode: "0755"
+
+- name: Copy over python_check fact file
+  template:
+    src: templates/pyenv_python_installations.fact.j2
+    dest: /etc/ansible/facts.d/pyenv_python_installations.fact
+    owner: "{{ pyenv_owner }}"
+    group: "{{ pyenv_owner }}"
+    mode: "0755"
+
+- name: Reload setup to gather custom facts
+  setup:
+    filter: ansible_local

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,13 @@
 - name: Update Pyenv interpreter list
   shell: . {{ pyenv_path }}/.pyenvrc && pyenv update
   when: pyenv_update
-  
+
+- name: Uninstall existing Python interpreters w/ wrong compilation flags
+  shell: ". {{ pyenv_path }}/.pyenvrc && pyenv uninstall -f {{ item }}"
+  args:
+    removes: "{{ pyenv_path }}/versions/{{ item }}/bin/python"
+  loop: "{{ ansible_local['pyenv_python_installations']['to_reinstall'] | default([]) }}"
+
 - name: Install Python interpreters "{{ pyenv_python_versions }}"
   shell: . {{ pyenv_path }}/.pyenvrc && env PYTHON_CONFIGURE_OPTS="{{ pyenv_python_configure_opts }}" pyenv install {{ item }}
          creates="{{ pyenv_path }}/versions/{{ item }}/bin/python"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -48,6 +48,7 @@
   args:
     removes: "{{ pyenv_path }}/versions/{{ item }}/bin/python"
   loop: "{{ ansible_local['pyenv_python_installations']['to_reinstall'] | default([]) }}"
+  when: pyenv_uninstall_python_w_wrong_configure_opts
 
 - name: Install Python interpreters "{{ pyenv_python_versions }}"
   shell: ". {{ pyenv_path }}/.pyenvrc && pyenv install {{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,8 +50,11 @@
   loop: "{{ ansible_local['pyenv_python_installations']['to_reinstall'] | default([]) }}"
 
 - name: Install Python interpreters "{{ pyenv_python_versions }}"
-  shell: . {{ pyenv_path }}/.pyenvrc && env PYTHON_CONFIGURE_OPTS="{{ pyenv_python_configure_opts }}" pyenv install {{ item }}
-         creates="{{ pyenv_path }}/versions/{{ item }}/bin/python"
+  shell: ". {{ pyenv_path }}/.pyenvrc && pyenv install {{ item }}"
+  environment:
+    PYTHON_CONFIGURE_OPTS: "{{ pyenv_python_configure_opts }}"
+  args:
+    creates: "{{ pyenv_path }}/versions/{{ item }}/bin/python"
   with_items: "{{ pyenv_python_versions }}"
 
 - name: Create virtual environments

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,27 @@
 ---
+- include: custom_facts.yml
+  become: true
+  become_user: "{{ pyenv_owner }}"
+  when: pyenv_env == "user"
+
+- include: custom_facts.yml
+  become: true
+  when: pyenv_env == "system"
+
 - include: Darwin.yml
   when: ansible_os_family == "Darwin"
 
 - include: Debian.yml
   when: ansible_os_family == "Debian"
-  
+
 - include: RedHat.yml
   when: ansible_os_family == "RedHat"
-
 
 - include: install.yml
   become: true
   become_user: "{{ pyenv_owner }}"
   when: pyenv_env == "user"
-  
+
 - include: install.yml
   become: true
   when: pyenv_env == "system"
-

--- a/templates/check-configure-options.py.j2
+++ b/templates/check-configure-options.py.j2
@@ -1,0 +1,6 @@
+import sysconfig
+
+config_args = sysconfig.get_config_var("CONFIG_ARGS")
+config_args = config_args.replace("'", "").split()
+required_args = {{ pyenv_python_configure_opts.split() }}
+print(all(s in config_args for s in required_args))

--- a/templates/pyenv_python_installations.fact.j2
+++ b/templates/pyenv_python_installations.fact.j2
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+configure_opts_checker="/etc/ansible/facts.d/check-configure-options.py"
+
+declare -a installs_to_check=({{ " ".join(pyenv_python_versions) }})
+declare -a to_reinstall=()
+declare -a to_install=()
+
+# Join array to string
+function join { local IFS="$1"; shift; echo "[$*]"; }
+
+for version in "${installs_to_check[@]}"
+do
+py_installation="{{ pyenv_path }}/versions/$version/bin/python"
+
+    if [[ -x "$py_installation" ]]; then
+        is_valid_install=$("$py_installation" "$configure_opts_checker")
+
+        if [[ $is_valid_install =~ "False" ]]; then
+            to_reinstall+=("\"$version\"")
+        fi
+    else
+        to_install+=("\"$version\"")
+    fi
+done
+
+to_reinstall_str=$(join , ${to_reinstall[@]})
+to_install_str=$(join , ${to_install[@]})
+printf "{ \"to_reinstall\": "$to_reinstall_str", \"to_install\": "$to_install_str" }\n"


### PR DESCRIPTION
I, like @makkus in issue #37 , was trying to add the ability to specify PYTHON_CONFIGURE_OPTS.  My addition adds a script that checks existing Python interpreters so we can re-install them with the configure options of their choice.

It also refactors the `Install Python interpreters "{{ pyenv_python_versions }}"` task to put the `creates` option under `args` and the `PYTHON_CONFIGURE_OPTS` option under `environment`.