### PR TITLE
Changes `creates=` check to full venv path instead of symlink

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -60,7 +60,7 @@
 
 - name: Create virtual environments
   shell: . {{ pyenv_path }}/.pyenvrc && pyenv virtualenv {{ item.py_version }} {{ item.venv_name }}
-         creates="{{ pyenv_path }}/versions/{{ item.venv_name }}/bin/python"
+         creates="{{ pyenv_path }}/versions/{{ item.py_version }}/envs/{{ item.venv_name }}/bin/python"
   with_items: "{{ pyenv_virtualenvs }}"
 
 - name: Set pyenv global


### PR DESCRIPTION
Modifies the `Create virtual environments` task to check for the actual python version venv instead of the symlink so the venv can be updated even if the name is not changed.

Fixes #14