### PR TITLE
Solution for pyenv issue #1906

### DIFF
--- a/templates/.pyenvrc.j2
+++ b/templates/.pyenvrc.j2
@@ -2,4 +2,5 @@
 # -------------------------------------
 export PYENV_ROOT="{{ pyenv_path }}"
 export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init --path)"
 eval "$(pyenv init - {{ pyenv_init_options}})"


### PR DESCRIPTION
Pyenv has changed how it's loading pyenv environmental variables and it affects this playbook.

Currently I'm getting error running automated tasks within pyenv, even scp jobs are affected

```
WARNING: `pyenv init -` no longer sets PATH.
Run `pyenv init` to see the necessary changes to make to your configuration.
Current dir /home/gitlab-runner/builds/PC6FYtMs/0/biteam/juryduty/deploy
WARNING: `pyenv init -` no longer sets PATH.
ERROR: Job failed: exit status 1
```

Running `pyenv init` produces the following output 

```
# (The below instructions are intended for common
# shell setups. See the README for more guidance
# if they don't apply and/or don't work for you.)

# Add pyenv executable to PATH and
# enable shims by adding the following
# to ~/.profile:

export PYENV_ROOT="$HOME/.pyenv"
export PATH="$PYENV_ROOT/bin:$PATH"
eval "$(pyenv init --path)"

# If your ~/.profile sources ~/.bashrc,
# the lines need to be inserted before the part
# that does that. See the README for another option.

# If you have ~/.bash_profile, make sure that it
# also executes the above lines -- e.g. by
# copying them there or by sourcing ~/.profile

# Load pyenv into the shell by adding
# the following to ~/.bashrc:

eval "$(pyenv init -)"

# Make sure to restart your entire logon session
# for changes to profile files to take effect.
```

Basically need to add `eval "$(pyenv init --path)"` before `eval "$(pyenv init -)"`, which is recommended in https://github.com/pyenv/pyenv/issues/1906 and which is done in this pull request