### PR TITLE
Fix libselinux-python on RHEL8/CentOS8 #45

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ pyenv_redhat_packages:
   - make
   - git
   - gcc
-  - libselinux-python
+  - "{{ ( (ansible_facts.distribution_major_version | default(0) | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
   - zlib-devel
   - openssl-devel
   - bzip2-devel


### PR DESCRIPTION
No package libselinux-python available on RHEL8/CentOS8

https://github.com/avanov/ansible-galaxy-pyenv/issues/45