### PR TITLE
Convert `include` to `include_tasks` for ansible-core 2.16 compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
-- include: custom_facts.yml
+- include_tasks: custom_facts.yml
   become: true
 
-- include: Darwin.yml
+- include_tasks: Darwin.yml
   when: ansible_os_family == "Darwin"
 
-- include: Debian.yml
+- include_tasks: Debian.yml
   when: ansible_os_family == "Debian"
 
-- include: RedHat.yml
+- include_tasks: RedHat.yml
   when: ansible_os_family == "RedHat"
 
-- include: install.yml
+- include_tasks: install.yml
   become: true
   become_user: "{{ pyenv_owner }}"
   when: pyenv_env == "user"
 
-- include: install.yml
+- include_tasks: install.yml
   become: true
   when: pyenv_env == "system"

--- a/test.yml
+++ b/test.yml
@@ -5,4 +5,4 @@
   tasks:
     - debug:
         msg: "Owner: {{ pyenv_owner }}"
-    - include: 'tasks/main.yml'
+    - include_tasks: 'tasks/main.yml'

--- a/test_update.yml
+++ b/test_update.yml
@@ -6,4 +6,4 @@
   tasks:
     - debug:
         msg: "Owner: {{ pyenv_owner }}"
-    - include: 'tasks/main.yml'
+    - include_tasks: 'tasks/main.yml'


### PR DESCRIPTION
Trying to use the role with Ansible 9 (using `ansible-core` 2.16), I get an error:
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```

This PR should fix it.